### PR TITLE
Update GitHub Actions Workflow for Version Bumping and Tagging

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,21 +1,32 @@
 name: Bump Version and Tag
 
 on:
+  workflow_dispatch:
+    inputs:
+      level:
+        description: "Version bump level"
+        required: true
+        default: "patch"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
   push:
-    branches: [master] # Only trigger when changes are pushed to master
+    branches: [master]
 
 jobs:
   bump:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write # Needed to push changes and tags
+      contents: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Required to get all tags
+          fetch-depth: 0
 
       - name: Setup Git
         run: |
@@ -33,20 +44,33 @@ jobs:
         id: next
         run: |
           version="${{ steps.get_tag.outputs.latest }}"
-          version="${version#v}"  # remove the leading 'v'
+          version="${version#v}"
           IFS='.' read -r major minor patch <<< "$version"
 
-          patch=$((patch + 1))
+          bump="${{ github.event.inputs.level || 'patch' }}"
+
+          if [[ "$bump" == "major" ]]; then
+            major=$((major + 1))
+            minor=0
+            patch=0
+          elif [[ "$bump" == "minor" ]]; then
+            minor=$((minor + 1))
+            patch=0
+          else
+            patch=$((patch + 1))
+          fi
+
           new_version="v$major.$minor.$patch"
           echo "New version: $new_version"
           echo "new_tag=$new_version" >> $GITHUB_OUTPUT
 
       - name: Create and push tag
         run: |
+          new_version="${{ steps.next.outputs.new_tag }}"
           git fetch --tags
           if git rev-parse "$new_version" >/dev/null 2>&1; then
             echo "Tag $new_version already exists, skipping..."
           else
-            git tag ${{ steps.next.outputs.new_tag }}
-            git push origin ${{ steps.next.outputs.new_tag }}
+            git tag -a "$new_version" -m "Release $new_version"
+            git push origin "$new_version"
           fi

--- a/.github/workflows/cpp-multi-platform.yml
+++ b/.github/workflows/cpp-multi-platform.yml
@@ -63,6 +63,15 @@ jobs:
       #     files: build/logs/coverage.xml
       #     name: codecov-${{ matrix.os }}
 
+      - name: Check if test log exists
+        run: |
+          if [ ! -f build/logs/test.log ]; then
+            echo "Test log not found!"
+            exit 1
+          else
+            echo "Test log found."
+          fi
+
       - name: Send success email with log
         if: success()
         uses: dawidd6/action-send-mail@v2

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
 ![GitHub](https://img.shields.io/github/license/minh-9999/Rental-Vehicle)
 
 <!-- Platform support -->
-![Platform](https://img.shields.io/badge/platform-linux--windows--macos-blue)
+![Platform](https://img.shields.io/badge/Platform-Linux--Windows--MacOS-blue)
 
 <!-- CMake badge -->
-![CMake](https://img.shields.io/badge/build%20system-CMake-informational)
+![CMake](https://img.shields.io/badge/Build%20system-CMake-informational)
 
 <!-- C++ version -->
 ![C++20](https://img.shields.io/badge/C%2B%2B-20-blue)
@@ -67,18 +67,20 @@ Logs will be saved in build/logs/test.log.
 
 ## 🗂 Project Structure
 
-.  
-├── src/                  		# Core source code  
-├── template-test/        		# YAML files for test config  
-├── test/                 		# Unit & Integration tests  
-├── script/               		# Test & build scripts  
-├── third_party/          		# External libraries (e.g., fmt, gtest)  
-├── build/                		# CMake build output  
-├── resource/                	# Assets (icons, etc.)  
-└── CMakeLists.txt  
+| Folder            | Description                                      |
+|-------------------|--------------------------------------------------|
+| `src/`            | Core source code                                 |
+| `template-test/`  | YAML files for test config                       |
+| `test/`           | Unit & Integration tests                         |
+| `script/`         | Test & build scripts                             |
+| `third_party/`    | External libraries (e.g., fmt, gtest)            |
+| `build/`          | CMake build output                               |
+| `resource/`       | Assets (icons, etc.)                             |
+| `CMakeLists.txt`  | CMake build configuration file                   |
+
 
 
 ## 📫 Contact
 
 📧 ngodinhhai.hcm@gmail.com  
-🌐 https://github.com/minh-9999
+


### PR DESCRIPTION
# Pull Request: Update GitHub Actions Workflow for Version Bumping and Tagging

## What's changed?

- **Updated the `Bump Version and Tag` workflow:**
  - Added a new `workflow_dispatch` trigger to allow manual version bump (patch, minor, major).
  - Modified the logic to calculate the next version based on the current version tag.
  - Implemented a check to ensure tags are only pushed if they don’t already exist.
  - Now supports manual version bump when triggered via the GitHub Actions UI.

## Why this change?

- This update makes it easier to manually bump versions from the GitHub UI.
- The previous setup only allowed version bumping on pushes to `master`, but now you can control when to bump versions using the GitHub Actions UI (`workflow_dispatch`).
- This will improve version management, allowing for more flexible versioning.

## How to use:

- Trigger the version bump manually via GitHub Actions UI:
  - Go to the **Actions** tab on your repository.
  - Select the `Bump Version and Tag` workflow.
  - Click on **Run workflow** and choose the version bump level (`patch`, `minor`, or `major`).
- This workflow will automatically create a new version tag and push it to the repository.

## Additional Information:

- This change also ensures that tags will be created with proper versioning format (e.g., `v1.2.3`).
- If a tag already exists, it will be skipped to prevent duplicates.
  
## Checklist:

- [x] I have tested the workflow locally or in a separate branch.
- [x] I have updated documentation (if applicable).
- [x] The workflow can now be triggered manually.

